### PR TITLE
Remove duplicated function

### DIFF
--- a/stash.el
+++ b/stash.el
@@ -98,9 +98,6 @@ The filename is expanded within the context of
 (defsubst stash-default-value (variable)
   (get variable 'stash-default-value))
 
-(defsubst stash-app-members (app)
-  (cdr (stash-app app)))
-
 (defsubst stash-owning-app (variable)
   (get variable 'stash-app))
 


### PR DESCRIPTION
In original code, `stash-app-members` is defined two times.
- https://github.com/vermiculus/stash.el/blob/638ae8a4f6d33af54fe77d57c2c0eb1800dd2e19/stash.el#L75
- https://github.com/vermiculus/stash.el/blob/638ae8a4f6d33af54fe77d57c2c0eb1800dd2e19/stash.el#L101
